### PR TITLE
Fix error thrown when creating child injector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saft",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saft",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "bluebird": "^3.7.2",
@@ -23,7 +23,6 @@
         "reflect-metadata": "^0.1.3",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.7",
-        "tslib": "^2.3.1",
         "typescript": "^4.4.4"
       }
     },
@@ -6809,12 +6808,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
-    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -12492,12 +12485,6 @@
           }
         }
       }
-    },
-    "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
     },
     "type": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saft",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "author": "Surikat AB",
   "license": "MIT",
@@ -26,7 +26,6 @@
     "reflect-metadata": "^0.1.3",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.7",
-    "tslib": "^2.3.1",
     "typescript": "^4.4.4"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "CommonJS",
     "target": "ES5",
     "lib": ["esnext"],
-    "importHelpers": true,
     "declaration": true,
     "rootDir": "./src",
     "outDir": "./lib",


### PR DESCRIPTION
We can either remove tslib and stop importing helpers, or move tslib to an actual dependency.

In this case, I don't think the benefits of tslib helpers is worth it being included.