### PR TITLE
Provide context to Provide annotation error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saft",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saft",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "bluebird": "^3.7.2",
@@ -8646,8 +8646,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -9342,8 +9341,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-6.2.0.tgz",
       "integrity": "sha1-SigZaqRhfeAbjJFOmSqC5dCIam4=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-surikat": {
       "version": "1.2.2",
@@ -10895,8 +10893,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.0.6",
@@ -12739,8 +12736,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saft",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "author": "Surikat AB",
   "license": "MIT",

--- a/src/annotations/ProvidesAnnotation.ts
+++ b/src/annotations/ProvidesAnnotation.ts
@@ -42,7 +42,7 @@ export class ProvidesAnnotation extends BindingAnnotation {
     const keysLength = inject.getKeys().length;
 
     if (keysLength !== fnLength) {
-      throw new Error(`@Provides function has unsatisfied parameters. @Inject specifies ${keysLength} keys and function expects ${fnLength} parameters`);
+      throw new Error(`Function "${String(targetKey)}" for "@Provides('${this.key}')" has unsatisfied parameters. @Inject specifies ${keysLength} keys and function expects ${fnLength} parameters`);
     }
 
     return this.bindToScope({ binder, fn, scope, target, keys: inject.getKeys() });

--- a/test/module.spec.ts
+++ b/test/module.spec.ts
@@ -116,6 +116,25 @@ describe('Injector', () => {
       const c2 = injector.get('counter');
       expect(c1).toBe(c2);
     });
+
+    it('should provide information about method unsatisfied parameters for argument length mismatch', (done) => {
+      class MyModule {
+        @Singleton()
+        @Provides('counter')
+        @Inject('a', 'b')
+        getCounter(_a: string) {
+        }
+      }
+
+      try {
+        new Injector(new MyModule());
+        done(new Error('Should give error on unsatisfied parameters for argument length mismatch '))
+      } catch (err: any) {
+        expect(err.message).toBe(`Function "getCounter" for "@Provides('counter')" has unsatisfied parameters. @Inject specifies 2 keys and function expects 1 parameters`)
+        done();
+      }
+    });
+
     it('should call configure on module', (done) => {
       class MyModule {
         configure() {


### PR DESCRIPTION
Provides context to the Error being displayed if the method parameters and the amount of injected modules differ. Makes it easier to track where the error occurs.

## Before

```sh
@Provides function has unsatisfied parameters. @Inject specifies 2 keys and function expects 1 parameters
```

## After

```sh
Function "getCounter" for "@Provides('counter')" has unsatisfied parameters. @Inject specifies 2 keys and function expects 1 parameters
```